### PR TITLE
Toggle settings submenu in vertical navigation

### DIFF
--- a/posts/static/css/styles_dark.css
+++ b/posts/static/css/styles_dark.css
@@ -121,9 +121,13 @@ body {
     list-style: none;
     padding-left: 44px;
     margin: 12px 0 0;
-    display: flex;
+    display: none;
     flex-direction: column;
     gap: 8px;
+}
+
+.settings-submenu.settings-submenu--visible {
+    display: flex;
 }
 
 .nav-sublink {

--- a/posts/static/css/styles_light.css
+++ b/posts/static/css/styles_light.css
@@ -454,9 +454,13 @@ p.member-followers-title {
     list-style: none;
     padding-left: 44px;
     margin: 12px 0 0;
-    display: flex;
+    display: none;
     flex-direction: column;
     gap: 8px;
+}
+
+.settings-submenu.settings-submenu--visible {
+    display: flex;
 }
 
 .nav-sublink {

--- a/posts/static/js/settings_menu.js
+++ b/posts/static/js/settings_menu.js
@@ -1,0 +1,58 @@
+(function () {
+    document.addEventListener('DOMContentLoaded', function () {
+        var toggle = document.querySelector('[data-settings-toggle]');
+        var submenu = document.querySelector('[data-settings-submenu]');
+
+        if (!toggle || !submenu) {
+            return;
+        }
+
+        var navItem = toggle.closest('.nav-item-settings');
+
+        var openClass = 'settings-submenu--visible';
+
+        submenu.setAttribute('aria-hidden', 'true');
+
+        var closeSubmenu = function () {
+            toggle.setAttribute('aria-expanded', 'false');
+            submenu.classList.remove(openClass);
+            submenu.setAttribute('aria-hidden', 'true');
+            if (navItem) {
+                navItem.classList.remove('settings-submenu-open');
+            }
+        };
+
+        toggle.addEventListener('click', function (event) {
+            var isExpanded = toggle.getAttribute('aria-expanded') === 'true';
+
+            if (!isExpanded) {
+                event.preventDefault();
+                toggle.setAttribute('aria-expanded', 'true');
+                submenu.classList.add(openClass);
+                submenu.setAttribute('aria-hidden', 'false');
+                if (navItem) {
+                    navItem.classList.add('settings-submenu-open');
+                }
+                return;
+            }
+
+            closeSubmenu();
+        });
+
+        document.addEventListener('click', function (event) {
+            if (!submenu.classList.contains(openClass)) {
+                return;
+            }
+
+            if (submenu.contains(event.target)) {
+                return;
+            }
+
+            if (event.target === toggle || toggle.contains(event.target)) {
+                return;
+            }
+
+            closeSubmenu();
+        });
+    });
+})();

--- a/posts/templates/base/base.html
+++ b/posts/templates/base/base.html
@@ -36,5 +36,6 @@
 
 <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js" integrity="sha384-YvpcrYf0tY3lHB60NNkmXc5s9fDVZLESaAA55NDzOxhy9GkcIdslK1eN7N6jIeHz" crossorigin="anonymous"></script>
 <script src="/static/js/theme_switcher.js" defer></script>
+<script src="/static/js/settings_menu.js" defer></script>
 {% block scripts %}{% endblock %}
 </html>

--- a/posts/templates/base/vertical_nav_base.html
+++ b/posts/templates/base/vertical_nav_base.html
@@ -25,11 +25,23 @@
     <ul class="navbar-nav nav-bottom">
         {% if user.is_authenticated %}
             <li class="nav-item nav-item-settings">
-                <a class="nav-link nav-link-static" href="/members/profile/{{ user.username }}#settings">
+                <a
+                    class="nav-link nav-link-static"
+                    href="/members/profile/{{ user.username }}#settings"
+                    data-settings-toggle
+                    role="button"
+                    aria-expanded="false"
+                    aria-controls="settings-submenu"
+                >
                     <i class="bi bi-gear-fill"></i>
                     <p class="nav-title">Налаштування</p>
                 </a>
-                <ul class="settings-submenu">
+                <ul
+                    class="settings-submenu"
+                    id="settings-submenu"
+                    data-settings-submenu
+                    aria-hidden="true"
+                >
                     <li>
                         <a class="nav-sublink" href="/members/profile/{{ user.username }}#notifications">
                             <i class="bi bi-bell-fill"></i>


### PR DESCRIPTION
## Summary
- hide the vertical navigation settings submenu until the main settings link is toggled
- add a script that opens and closes the submenu on click, updating accessibility attributes
- load the new script globally so the behaviour is available anywhere the vertical nav is rendered