### PR TITLE
Add discover like button styling and populate profile settings sections

### DIFF
--- a/members/templates/profile/profile.html
+++ b/members/templates/profile/profile.html
@@ -7,5 +7,7 @@
         {% include 'profile/profile_card.html' with member_age=member_age %}
 
         {% include 'profile/recommendations.html' with recommendations=recommendations %}
+
+        {% include 'profile/settings.html' %}
     </div>
 {% endblock %}

--- a/members/templates/profile/settings.html
+++ b/members/templates/profile/settings.html
@@ -1,0 +1,88 @@
+<section id="settings" class="profile-settings mt-4">
+    <div class="card profile-settings__intro">
+        <div class="card-body">
+            <h2 class="h4 mb-2">Налаштування</h2>
+            <p class="mb-0 text-muted">Керуйте своїм досвідом у Lixy: оберіть, які сповіщення отримувати, як ми показуємо ваш профіль та перегляньте основні правила спільноти.</p>
+        </div>
+    </div>
+
+    <div class="profile-settings__grid">
+        <article id="notifications" class="card profile-settings__card">
+            <div class="card-body">
+                <div class="profile-settings__card-header">
+                    <i class="bi bi-bell-fill" aria-hidden="true"></i>
+                    <h3 class="h5 mb-0">Сповіщення</h3>
+                </div>
+                <p class="text-muted small">Отримуйте лише потрібні вам оновлення, щоб залишатися на зв’язку з людьми, які вам цікаві.</p>
+                <div class="profile-settings__options" role="group" aria-labelledby="notifications">
+                    <div class="form-check form-switch">
+                        <input class="form-check-input" type="checkbox" id="notify-matches" checked>
+                        <label class="form-check-label" for="notify-matches">Повідомляти про нові збіги</label>
+                    </div>
+                    <div class="form-check form-switch">
+                        <input class="form-check-input" type="checkbox" id="notify-messages" checked>
+                        <label class="form-check-label" for="notify-messages">Надсилати сповіщення про нові повідомлення</label>
+                    </div>
+                    <div class="form-check form-switch">
+                        <input class="form-check-input" type="checkbox" id="notify-recommendations">
+                        <label class="form-check-label" for="notify-recommendations">Підказувати нові рекомендації електронною поштою</label>
+                    </div>
+                </div>
+            </div>
+        </article>
+
+        <article id="privacy" class="card profile-settings__card">
+            <div class="card-body">
+                <div class="profile-settings__card-header">
+                    <i class="bi bi-shield-lock-fill" aria-hidden="true"></i>
+                    <h3 class="h5 mb-0">Конфіденційність</h3>
+                </div>
+                <p class="text-muted small">Обирайте, хто може бачити ваш профіль та які дані ви відкриваєте для інших.</p>
+                <ul class="profile-settings__list">
+                    <li>Показувати профіль лише для людей із взаємними вподобаннями.</li>
+                    <li>Приховати вік у публічній частині профілю.</li>
+                    <li>Відображати ваш населений пункт тільки вашим збігам.</li>
+                </ul>
+            </div>
+        </article>
+
+        <article id="rules" class="card profile-settings__card">
+            <div class="card-body">
+                <div class="profile-settings__card-header">
+                    <i class="bi bi-journal-check" aria-hidden="true"></i>
+                    <h3 class="h5 mb-0">Правила</h3>
+                </div>
+                <p class="text-muted small">Пам’ятайте про комфорт і безпеку всіх користувачів — це допомагає будувати здорову спільноту.</p>
+                <ul class="profile-settings__list">
+                    <li>Поважайте особисті межі та не діліться чужими контактами без дозволу.</li>
+                    <li>Повідомляйте про підозрілу поведінку — команда підтримки завжди на зв’язку.</li>
+                    <li>Використовуйте справжні фото та опис, щоб збіги були чесними.</li>
+                </ul>
+            </div>
+        </article>
+
+        <article id="subscriptions" class="card profile-settings__card">
+            <div class="card-body">
+                <div class="profile-settings__card-header">
+                    <i class="bi bi-repeat" aria-hidden="true"></i>
+                    <h3 class="h5 mb-0">Налаштування підписок</h3>
+                </div>
+                <p class="text-muted small">Оберіть оптимальний план, щоб бачити більше профілів та отримувати ексклюзивні можливості.</p>
+                <div class="profile-settings__options">
+                    <div>
+                        <h4 class="h6 mb-1">Lixy Plus</h4>
+                        <p class="mb-2 small text-muted">Додаткові вподобання щодня та перегляд тих, кому ви сподобалися.</p>
+                    </div>
+                    <div>
+                        <h4 class="h6 mb-1">Lixy Premium</h4>
+                        <p class="mb-2 small text-muted">Необмежені повернення, пріоритет у видачі та детальна аналітика збігів.</p>
+                    </div>
+                </div>
+                <div class="d-flex justify-content-between align-items-center profile-settings__cta">
+                    <span class="fw-semibold">Поточний план: Безкоштовний</span>
+                    <a href="/members/profile/{{ member.username }}#subscriptions" class="btn btn-primary btn-sm">Оновити план</a>
+                </div>
+            </div>
+        </article>
+    </div>
+</section>

--- a/posts/static/css/discover.css
+++ b/posts/static/css/discover.css
@@ -161,6 +161,29 @@
     align-items: center;
 }
 
+.swipe-actions__buttons .swipe-button[data-action="like"] {
+    background: linear-gradient(135deg, #ef476f, #ff9a62);
+    border: none;
+    color: #fff;
+    box-shadow: 0 12px 24px rgba(239, 71, 111, 0.35);
+    transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+.swipe-actions__buttons .swipe-button[data-action="like"]:hover {
+    transform: translateY(-2px) scale(1.01);
+    box-shadow: 0 16px 32px rgba(239, 71, 111, 0.4);
+}
+
+.swipe-actions__buttons .swipe-button[data-action="like"]:active {
+    transform: translateY(0) scale(0.98);
+    box-shadow: 0 8px 18px rgba(239, 71, 111, 0.4);
+}
+
+.swipe-actions__buttons .swipe-button[data-action="like"] i,
+.swipe-actions__buttons .swipe-button[data-action="like"] span {
+    color: inherit;
+}
+
 .swipe-active-profile {
     display: flex;
     align-items: center;

--- a/posts/static/css/styles_dark.css
+++ b/posts/static/css/styles_dark.css
@@ -714,3 +714,65 @@ p.member-followers-title {
     height: 56px;
     object-fit: cover;
 }
+
+.profile-settings {
+    width: 100%;
+    display: flex;
+    flex-direction: column;
+    gap: 1.5rem;
+    text-align: left;
+}
+
+.profile-settings__intro .card-body {
+    text-align: left;
+}
+
+.profile-settings__grid {
+    display: grid;
+    gap: 1.5rem;
+    grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+}
+
+.profile-settings__card {
+    height: 100%;
+    text-align: left;
+    background-color: var(--card-bg);
+    border: var(--card-border);
+}
+
+.profile-settings__card-header {
+    display: flex;
+    align-items: center;
+    gap: 0.75rem;
+    margin-bottom: 0.75rem;
+}
+
+.profile-settings__card-header i {
+    font-size: 1.5rem;
+    color: var(--icon-color);
+}
+
+.profile-settings__options {
+    display: flex;
+    flex-direction: column;
+    align-items: flex-start;
+    gap: 0.75rem;
+}
+
+.profile-settings__list {
+    margin: 0;
+    padding-left: 1.2rem;
+    display: flex;
+    flex-direction: column;
+    gap: 0.5rem;
+    text-align: left;
+}
+
+.profile-settings__cta {
+    margin-top: 1.25rem;
+}
+
+.profile-settings__card .form-check-input,
+.profile-settings__card .form-check-label {
+    cursor: pointer;
+}

--- a/posts/static/css/styles_light.css
+++ b/posts/static/css/styles_light.css
@@ -519,3 +519,62 @@ p.member-followers-title {
     height: 56px;
     object-fit: cover;
 }
+
+.profile-settings {
+    width: 100%;
+    display: flex;
+    flex-direction: column;
+    gap: 1.5rem;
+    text-align: left;
+}
+
+.profile-settings__intro .card-body {
+    text-align: left;
+}
+
+.profile-settings__grid {
+    display: grid;
+    gap: 1.5rem;
+    grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+}
+
+.profile-settings__card {
+    height: 100%;
+    text-align: left;
+}
+
+.profile-settings__card-header {
+    display: flex;
+    align-items: center;
+    gap: 0.75rem;
+    margin-bottom: 0.75rem;
+}
+
+.profile-settings__card-header i {
+    font-size: 1.5rem;
+}
+
+.profile-settings__options {
+    display: flex;
+    flex-direction: column;
+    align-items: flex-start;
+    gap: 0.75rem;
+}
+
+.profile-settings__list {
+    margin: 0;
+    padding-left: 1.2rem;
+    display: flex;
+    flex-direction: column;
+    gap: 0.5rem;
+    text-align: left;
+}
+
+.profile-settings__cta {
+    margin-top: 1.25rem;
+}
+
+.profile-settings__card .form-check-input,
+.profile-settings__card .form-check-label {
+    cursor: pointer;
+}


### PR DESCRIPTION
## Summary
- restyle the swipe "Вподобати" button on the discover page so it uses a solid gradient background and hover/active feedback
- add dedicated settings sections to the profile page for notifications, privacy, community rules, and subscription options
- style the new settings layout for both light and dark themes to keep the cards readable