### PR TITLE
Refine settings layout and remove light theme

### DIFF
--- a/members/templates/profile/settings/notifications.html
+++ b/members/templates/profile/settings/notifications.html
@@ -4,7 +4,7 @@
 
 {% block content %}
 <section class="profile-settings mt-4">
-    <a class="btn btn-link ps-0" href="{% url 'profile' member.username %}">
+    <a class="profile-settings__back" href="{% url 'profile' member.username %}">
         <i class="bi bi-arrow-left"></i>
         Повернутися до профілю
     </a>

--- a/members/templates/profile/settings/privacy.html
+++ b/members/templates/profile/settings/privacy.html
@@ -4,7 +4,7 @@
 
 {% block content %}
 <section class="profile-settings mt-4">
-    <a class="btn btn-link ps-0" href="{% url 'profile' member.username %}">
+    <a class="profile-settings__back" href="{% url 'profile' member.username %}">
         <i class="bi bi-arrow-left"></i>
         Повернутися до профілю
     </a>

--- a/members/templates/profile/settings/rules.html
+++ b/members/templates/profile/settings/rules.html
@@ -4,7 +4,7 @@
 
 {% block content %}
 <section class="profile-settings mt-4">
-    <a class="btn btn-link ps-0" href="{% url 'profile' member.username %}">
+    <a class="profile-settings__back" href="{% url 'profile' member.username %}">
         <i class="bi bi-arrow-left"></i>
         Повернутися до профілю
     </a>

--- a/members/templates/profile/settings/subscriptions.html
+++ b/members/templates/profile/settings/subscriptions.html
@@ -4,7 +4,7 @@
 
 {% block content %}
 <section class="profile-settings mt-4">
-    <a class="btn btn-link ps-0" href="{% url 'profile' member.username %}">
+    <a class="profile-settings__back" href="{% url 'profile' member.username %}">
         <i class="bi bi-arrow-left"></i>
         Повернутися до профілю
     </a>

--- a/posts/static/css/styles_dark.css
+++ b/posts/static/css/styles_dark.css
@@ -730,7 +730,13 @@ p.member-followers-title {
 .profile-settings__grid {
     display: grid;
     gap: 1.5rem;
-    grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+    width: 100%;
+}
+
+@media (min-width: 768px) {
+    .profile-settings__grid {
+        grid-template-columns: repeat(2, minmax(0, 1fr));
+    }
 }
 
 .profile-settings__card {
@@ -757,6 +763,38 @@ p.member-followers-title {
     flex-direction: column;
     align-items: flex-start;
     gap: 0.75rem;
+}
+
+.profile-settings__back {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.5rem;
+    padding: 0.5rem 0.9rem;
+    border-radius: 999px;
+    border: 1px solid var(--btn-secondary-border);
+    background-color: transparent;
+    color: var(--text-color);
+    font-weight: 600;
+    text-decoration: none;
+    transition: background-color 0.2s ease, border-color 0.2s ease, color 0.2s ease;
+}
+
+.profile-settings__back i {
+    font-size: 1rem;
+    color: currentColor;
+}
+
+.profile-settings__back:hover,
+.profile-settings__back:focus {
+    background-color: var(--btn-secondary-bg-hover);
+    border-color: var(--btn-secondary-border-hover);
+    color: var(--btn-secondary-text);
+    text-decoration: none;
+}
+
+.profile-settings__back:focus-visible {
+    outline: 2px solid var(--btn-secondary-border-hover);
+    outline-offset: 2px;
 }
 
 .profile-settings__list {

--- a/posts/templates/base/base.html
+++ b/posts/templates/base/base.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" rel="stylesheet" integrity="sha384-QWTKZyjpPEjISv5WaRU9OFeRpok6YctnYmDr5pNlyT2bRjXh0JMhjY6hW+ALEwIH" crossorigin="anonymous">
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.3/font/bootstrap-icons.min.css">
-    <link id="theme-link" rel="stylesheet" href="/static/css/styles_light.css">
+    <link rel="stylesheet" href="/static/css/styles_dark.css">
     {% block extra_head %}{% endblock %}
     <title>Lixy - {% block title %}Home{% endblock %}</title>
 </head>
@@ -35,7 +35,6 @@
 </body>
 
 <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js" integrity="sha384-YvpcrYf0tY3lHB60NNkmXc5s9fDVZLESaAA55NDzOxhy9GkcIdslK1eN7N6jIeHz" crossorigin="anonymous"></script>
-<script src="/static/js/theme_switcher.js" defer></script>
 <script src="/static/js/settings_menu.js" defer></script>
 {% block scripts %}{% endblock %}
 </html>

--- a/posts/templates/base/nav_base.html
+++ b/posts/templates/base/nav_base.html
@@ -34,13 +34,7 @@
                 </div>
             {% endif %}
 
-            <div class="navbar-collapse d-flex justify-content-end">
-                <ul class="navbar-nav">
-                    <li class="nav-item">
-                        <a class="nav-link theme-toggle" aria-current="page" href="" id="theme-toggle"><i class="bi bi-palette-fill"></i> Theme</a>
-                    </li>
-                </ul>
-            </div>
+            <div class="navbar-collapse d-flex justify-content-end"></div>
         </div>
     </div>
 </nav>


### PR DESCRIPTION
## Summary
- load the dark theme stylesheet by default and remove the theme toggle entry from the navigation
- adjust the settings grid layout and spacing so cards remain balanced on larger viewports
- style the "Повернутися до профілю" link as a dedicated back button across the settings pages