### PR TITLE
Center dialog title and enable message input

### DIFF
--- a/members/templates/profile/dialog_detail.html
+++ b/members/templates/profile/dialog_detail.html
@@ -34,9 +34,10 @@
             {% endif %}
         </div>
         <div class="card-footer">
-            <form class="dialog-form">
+            <form class="dialog-form" method="post" action="#">
+                {% csrf_token %}
                 <div class="input-group">
-                    <input type="text" class="form-control" placeholder="Напишіть повідомлення..." disabled>
+                    <input type="text" name="message" class="form-control" placeholder="Напишіть повідомлення...">
                     <button class="btn btn-primary" type="button" disabled>Надіслати</button>
                 </div>
                 <small class="text-muted d-block mt-2">Обмін повідомленнями незабаром буде доступний.</small>

--- a/members/templates/profile/dialog_list.html
+++ b/members/templates/profile/dialog_list.html
@@ -4,11 +4,9 @@
 
 {% block content %}
 <div class="dialog-list-page py-4">
-    <div class="d-flex align-items-center justify-content-between flex-wrap gap-2 mb-4">
-        <div>
-            <h1 class="dialog-list-title mb-0">Діалоги</h1>
-            <p class="dialog-list-subtitle mb-0">Спілкуйтеся з людьми, з якими вже є контакт.</p>
-        </div>
+    <div class="dialog-list-header mb-4">
+        <h1 class="dialog-list-title mb-0">Діалоги</h1>
+        <p class="dialog-list-subtitle mb-0">Спілкуйтеся з людьми, з якими вже є контакт.</p>
         {% if dialogs %}
             <span class="dialog-list-counter" aria-label="Кількість діалогів">{{ dialogs|length }}</span>
         {% endif %}

--- a/posts/static/css/styles_dark.css
+++ b/posts/static/css/styles_dark.css
@@ -790,6 +790,23 @@ form {
     text-align: left;
 }
 
+.dialog-list-header {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 12px;
+    text-align: center;
+}
+
+.dialog-list-header .dialog-list-title,
+.dialog-list-header .dialog-list-subtitle {
+    text-align: center;
+}
+
+.dialog-list-header .dialog-list-counter {
+    margin-top: 4px;
+}
+
 .dialog-list-title {
     text-align: left;
 }

--- a/posts/static/css/styles_light.css
+++ b/posts/static/css/styles_light.css
@@ -632,6 +632,23 @@ form {
     text-align: left;
 }
 
+.dialog-list-header {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 12px;
+    text-align: center;
+}
+
+.dialog-list-header .dialog-list-title,
+.dialog-list-header .dialog-list-subtitle {
+    text-align: center;
+}
+
+.dialog-list-header .dialog-list-counter {
+    margin-top: 4px;
+}
+
 .dialog-list-title {
     text-align: left;
 }


### PR DESCRIPTION
## Summary
- center the dialog list header so the title, subtitle, and counter align in the middle of the page
- add supporting styles for the new dialog list header layout in both light and dark themes
- allow the dialog detail form field to be focusable so users can type draft messages