### PR TITLE
Adjust dialog message bubble width

### DIFF
--- a/posts/static/css/styles_dark.css
+++ b/posts/static/css/styles_dark.css
@@ -1025,7 +1025,9 @@ form {
     padding: 12px;
     border-radius: 12px;
     background-color: rgba(234, 235, 241, 0.04);
-    max-width: min(100%, 360px);
+    width: -moz-fit-content;
+    width: fit-content;
+    max-width: 70%;
     box-shadow: 0 1px 2px rgba(0, 0, 0, 0.25);
 }
 

--- a/posts/static/css/styles_light.css
+++ b/posts/static/css/styles_light.css
@@ -871,7 +871,9 @@ form {
     padding: 12px;
     border-radius: 12px;
     background-color: rgba(10, 12, 16, 0.04);
-    max-width: min(100%, 360px);
+    width: -moz-fit-content;
+    width: fit-content;
+    max-width: 70%;
     box-shadow: 0 1px 2px rgba(10, 12, 16, 0.04);
 }
 


### PR DESCRIPTION
## Summary
- limit dialog message bubbles to content width with a 70% maximum in both themes so long texts wrap sooner

## Testing
- python manage.py check *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_68e2284c0b64832ba3bd26dead31c9a5