### PR TITLE
Adjust dialog message layout

### DIFF
--- a/members/templates/profile/dialog_detail.html
+++ b/members/templates/profile/dialog_detail.html
@@ -30,27 +30,22 @@
                         {% for message in day.messages %}
                             <li class="dialog-message-item {% if message.is_current_user %}dialog-message-item-out{% else %}dialog-message-item-in{% endif %}">
                                 <div class="dialog-message-main {% if message.is_current_user %}dialog-message-main-out{% else %}dialog-message-main-in{% endif %}">
-                                    {% if message.is_current_user %}
-                                        <div class="dialog-message-meta dialog-message-meta-out">
-                                            <span class="dialog-message-time">{{ message.time_display }}</span>
-                                            <i class="bi {% if message.is_read %}bi-check-all{% else %}bi-check{% endif %}" aria-hidden="true"></i>
-                                            <span class="visually-hidden">
-                                                {% if message.is_read %}
-                                                    Повідомлення прочитано
-                                                {% else %}
-                                                    Повідомлення надіслано
-                                                {% endif %}
-                                            </span>
-                                        </div>
-                                    {% endif %}
                                     <div class="dialog-message {% if message.is_current_user %}dialog-message-out{% else %}dialog-message-in{% endif %}">
                                         <span class="dialog-message-author">{{ message.author }}</span>
                                         <span class="dialog-message-text">{{ message.text }}</span>
                                     </div>
-                                    {% if not message.is_current_user %}
-                                        <div class="dialog-message-meta dialog-message-meta-in">
-                                            <span class="dialog-message-time">{{ message.time_display }}</span>
-                                        </div>
+                                </div>
+                                <div class="dialog-message-meta {% if message.is_current_user %}dialog-message-meta-out{% else %}dialog-message-meta-in{% endif %}">
+                                    <span class="dialog-message-time">{{ message.time_display }}</span>
+                                    {% if message.is_current_user %}
+                                        <i class="bi {% if message.is_read %}bi-check-all{% else %}bi-check{% endif %}" aria-hidden="true"></i>
+                                        <span class="visually-hidden">
+                                            {% if message.is_read %}
+                                                Повідомлення прочитано
+                                            {% else %}
+                                                Повідомлення надіслано
+                                            {% endif %}
+                                        </span>
                                     {% endif %}
                                 </div>
                                 {% if message.is_current_user and message.is_read %}

--- a/posts/static/css/styles_dark.css
+++ b/posts/static/css/styles_dark.css
@@ -1003,15 +1003,12 @@ form {
     align-items: flex-end;
 }
 
+
 .dialog-message-main {
     display: flex;
-    align-items: flex-end;
-    gap: 8px;
-    max-width: 100%;
-}
-
-.dialog-message-main-in {
     justify-content: flex-start;
+    max-width: 100%;
+    width: 100%;
 }
 
 .dialog-message-main-out {
@@ -1019,15 +1016,14 @@ form {
 }
 
 .dialog-message {
-    display: flex;
+    display: inline-flex;
     flex-direction: column;
+    align-items: flex-start;
     gap: 4px;
     padding: 12px;
     border-radius: 12px;
     background-color: rgba(234, 235, 241, 0.04);
-    width: -moz-fit-content;
-    width: fit-content;
-    max-width: 70%;
+    max-width: min(70%, 420px);
     box-shadow: 0 1px 2px rgba(0, 0, 0, 0.25);
 }
 
@@ -1052,14 +1048,23 @@ form {
 .dialog-message-meta {
     display: flex;
     align-items: center;
-    gap: 6px;
-    font-size: 0.75rem;
+    gap: 4px;
+    font-size: 0.7rem;
     color: var(--secondary-text-color);
     font-variant-numeric: tabular-nums;
+    margin-top: 4px;
+}
+
+.dialog-message-item-in .dialog-message-meta {
+    align-self: flex-start;
+}
+
+.dialog-message-item-out .dialog-message-meta {
+    align-self: flex-end;
 }
 
 .dialog-message-meta i {
-    font-size: 0.85rem;
+    font-size: 0.75rem;
     color: inherit;
 }
 

--- a/posts/static/css/styles_light.css
+++ b/posts/static/css/styles_light.css
@@ -849,15 +849,12 @@ form {
     align-items: flex-end;
 }
 
+
 .dialog-message-main {
     display: flex;
-    align-items: flex-end;
-    gap: 8px;
-    max-width: 100%;
-}
-
-.dialog-message-main-in {
     justify-content: flex-start;
+    max-width: 100%;
+    width: 100%;
 }
 
 .dialog-message-main-out {
@@ -865,15 +862,14 @@ form {
 }
 
 .dialog-message {
-    display: flex;
+    display: inline-flex;
     flex-direction: column;
+    align-items: flex-start;
     gap: 4px;
     padding: 12px;
     border-radius: 12px;
     background-color: rgba(10, 12, 16, 0.04);
-    width: -moz-fit-content;
-    width: fit-content;
-    max-width: 70%;
+    max-width: min(70%, 420px);
     box-shadow: 0 1px 2px rgba(10, 12, 16, 0.04);
 }
 
@@ -898,14 +894,23 @@ form {
 .dialog-message-meta {
     display: flex;
     align-items: center;
-    gap: 6px;
-    font-size: 0.75rem;
+    gap: 4px;
+    font-size: 0.7rem;
     color: #5c5e66;
     font-variant-numeric: tabular-nums;
+    margin-top: 4px;
+}
+
+.dialog-message-item-in .dialog-message-meta {
+    align-self: flex-start;
+}
+
+.dialog-message-item-out .dialog-message-meta {
+    align-self: flex-end;
 }
 
 .dialog-message-meta i {
-    font-size: 0.85rem;
+    font-size: 0.75rem;
     color: inherit;
 }
 


### PR DESCRIPTION
## Summary
- move message metadata beneath each bubble in the dialog template for clearer stacking
- tweak light and dark theme styles so bubbles size to their content and timestamps/checkmarks render smaller under the message