### PR TITLE
Ensure dialog list shows active conversations and tighten message spacing

### DIFF
--- a/posts/static/css/styles_dark.css
+++ b/posts/static/css/styles_dark.css
@@ -992,7 +992,7 @@ form {
 .dialog-message-item {
     display: flex;
     flex-direction: column;
-    gap: 6px;
+    gap: 2px;
 }
 
 .dialog-message-item-in {
@@ -1052,7 +1052,7 @@ form {
     font-size: 0.7rem;
     color: var(--secondary-text-color);
     font-variant-numeric: tabular-nums;
-    margin-top: 4px;
+    margin-top: 0;
 }
 
 .dialog-message-item-in .dialog-message-meta {

--- a/posts/static/css/styles_light.css
+++ b/posts/static/css/styles_light.css
@@ -838,7 +838,7 @@ form {
 .dialog-message-item {
     display: flex;
     flex-direction: column;
-    gap: 6px;
+    gap: 2px;
 }
 
 .dialog-message-item-in {
@@ -898,7 +898,7 @@ form {
     font-size: 0.7rem;
     color: #5c5e66;
     font-variant-numeric: tabular-nums;
-    margin-top: 4px;
+    margin-top: 0;
 }
 
 .dialog-message-item-in .dialog-message-meta {


### PR DESCRIPTION
## Summary
- include companions from recent messages when building the dialog list so conversations appear even without mutual following
- reuse the latest message per companion for previews while preserving ordering
- reduce the spacing between each dialog message and its timestamp/checkmark in both light and dark themes

## Testing
- python manage.py check *(fails: Django not installed in the environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e22b376710832b8f8314b8220a7042