### PR TITLE
Fix alert include path for message template

### DIFF
--- a/posts/templates/base/alerts_base.html
+++ b/posts/templates/base/alerts_base.html
@@ -1,7 +1,7 @@
 <div class="alerts-block">
     {% if messages %}
         {% for message in messages %}
-            {% include 'alert_card.html' %}
+            {% include 'alert/alert_card.html' %}
         {% endfor %}
     {% endif %}
 </div>


### PR DESCRIPTION
## Summary
- point the alert include tag to the existing alert_card template in the alert directory