### PR TITLE
Improve discover swipe UX and dialog indicators

### DIFF
--- a/members/templates/profile/discover.html
+++ b/members/templates/profile/discover.html
@@ -44,14 +44,6 @@
         </div>
 
         <div class="swipe-actions mt-4">
-            <div class="swipe-active-profile d-none" data-active-profile>
-                <img src="https://placehold.co/96x96?text=L" alt="Активний користувач" class="swipe-active-profile__avatar" data-active-avatar>
-                <div class="swipe-active-profile__info">
-                    <div class="swipe-active-profile__name" data-active-name></div>
-                    <div class="swipe-active-profile__meta text-muted" data-active-meta></div>
-                </div>
-            </div>
-
             <div class="swipe-actions__buttons d-flex justify-content-center flex-wrap gap-3">
                 <button type="button" class="btn btn-outline-secondary btn-lg swipe-button" data-action="dislike">
                     <i class="bi bi-x-lg"></i>

--- a/posts/static/css/discover.css
+++ b/posts/static/css/discover.css
@@ -191,11 +191,17 @@
     flex-direction: column;
     gap: 0;
     pointer-events: none;
+    user-select: none;
+    touch-action: pan-y;
 }
 
 .profile-card.active {
     pointer-events: auto;
-    cursor: pointer;
+    cursor: grab;
+}
+
+.profile-card.active[data-dragging="true"] {
+    cursor: grabbing;
 }
 
 .profile-card__photo {
@@ -328,33 +334,6 @@
 .swipe-actions__buttons .swipe-button[data-action="like"] i,
 .swipe-actions__buttons .swipe-button[data-action="like"] span {
     color: inherit;
-}
-
-.swipe-active-profile {
-    display: flex;
-    align-items: center;
-    gap: 1rem;
-    padding: 0.75rem 1rem;
-    border-radius: 999px;
-    background: var(--bs-body-bg);
-    box-shadow: 0 10px 25px rgba(15, 23, 42, 0.12);
-}
-
-.swipe-active-profile__avatar {
-    width: 64px;
-    height: 64px;
-    border-radius: 50%;
-    object-fit: cover;
-    border: 3px solid rgba(99, 102, 241, 0.3);
-}
-
-.swipe-active-profile__name {
-    font-weight: 600;
-    font-size: 1.05rem;
-}
-
-.swipe-active-profile__meta {
-    font-size: 0.9rem;
 }
 
 .swipe-feedback {

--- a/posts/static/css/styles_dark.css
+++ b/posts/static/css/styles_dark.css
@@ -895,14 +895,19 @@ form {
 }
 
 .dialog-status-dot {
-    width: 10px;
-    height: 10px;
+    width: 12px;
+    height: 12px;
     border-radius: 50%;
     display: inline-flex;
+    flex-shrink: 0;
+    border: 2px solid var(--card-bg);
+    box-shadow: 0 0 0 2px var(--card-bg);
+    background-color: #4a4c57;
 }
 
 .dialog-status-dot.is-online {
     background-color: #3ddc84;
+    box-shadow: 0 0 0 2px var(--card-bg), 0 0 0 6px rgba(61, 220, 132, 0.35);
 }
 
 .dialog-status-dot.is-offline {

--- a/posts/static/css/styles_light.css
+++ b/posts/static/css/styles_light.css
@@ -739,14 +739,19 @@ form {
 }
 
 .dialog-status-dot {
-    width: 10px;
-    height: 10px;
+    width: 12px;
+    height: 12px;
     border-radius: 50%;
     display: inline-flex;
+    flex-shrink: 0;
+    border: 2px solid #eaebf1;
+    box-shadow: 0 0 0 2px #eaebf1;
+    background-color: #b0b2b8;
 }
 
 .dialog-status-dot.is-online {
-    background-color: #2ecc71;
+    background-color: #22c55e;
+    box-shadow: 0 0 0 2px #eaebf1, 0 0 0 6px rgba(34, 197, 94, 0.3);
 }
 
 .dialog-status-dot.is-offline {


### PR DESCRIPTION
## Summary
- remove the floating active profile preview from the discover actions area
- enable mouse and touch dragging for cards with improved visual feedback while swiping
- highlight online dialogs with brighter status dots in both light and dark themes