### PR TITLE
Fix dialog form to show sent messages immediately

### DIFF
--- a/members/static/members/js/dialog.js
+++ b/members/static/members/js/dialog.js
@@ -158,7 +158,7 @@
         listElement.scrollTop = listElement.scrollHeight;
     }
 
-    function setupForm(form) {
+    function setupForm(form, { onMessage } = {}) {
         if (!form) {
             return;
         }
@@ -223,10 +223,13 @@
 
                     throw new Error(errorMessage);
                 })
-                .then(() => {
+                .then((payload) => {
                     form.reset();
                     if (messageField instanceof HTMLTextAreaElement) {
                         messageField.value = '';
+                    }
+                    if (typeof onMessage === 'function' && payload && payload.message) {
+                        onMessage(payload.message);
                     }
                 })
                 .catch((error) => {
@@ -386,7 +389,7 @@
         }
 
         const form = document.querySelector('.dialog-form');
-        setupForm(form);
+        setupForm(form, { onMessage: handleNewMessage });
 
         scrollToBottom(messagesList);
     });

--- a/members/views.py
+++ b/members/views.py
@@ -452,9 +452,11 @@ def dialog_detail(request, username):
             message.sender = request.user
             message.recipient = companion
             message.save()
+            payload = build_message_payload(message).__dict__
+            payload["is_current_user"] = True
             broadcast_new_message(message)
             if is_ajax:
-                return JsonResponse({"status": "ok"})
+                return JsonResponse({"status": "ok", "message": payload})
             return redirect('dialog_detail', username=companion.username)
         if is_ajax:
             return JsonResponse(


### PR DESCRIPTION
## Summary
- return the serialized message when posting a dialog message via AJAX
- update the dialog form script to append the newly sent message without a page refresh

## Testing
- python manage.py test *(fails: missing Django dependency in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e389ef0228832b97188ae995aa53d3